### PR TITLE
Fix for ackComment property

### DIFF
--- a/LogicMonitor.Api/Alerts/AlertAcknowledgement.cs
+++ b/LogicMonitor.Api/Alerts/AlertAcknowledgement.cs
@@ -3,11 +3,13 @@ namespace LogicMonitor.Api.Alerts
 	/// <summary>
 	/// An alert acknowledgement
 	/// </summary>
+	[DataContract]
 	public class AlertAcknowledgement
 	{
 		/// <summary>
 		/// The acknowledgement comment
 		/// </summary>
+		[DataMember(Name="ackComment")]
 		public string AcknowledgementComment { get; set; }
 	}
 }


### PR DESCRIPTION
Added attributes for the JsonSerializer to convert correctly.

The library doesn't send the correct json data to the LM API, which results in the API responding with "ackComment is missing".

Adding the attributes allows the JsonSerializer to convert the object to the correct json properties.