### PR TITLE
Update LogicMonitorClient.cs

### DIFF
--- a/LogicMonitor.Api/LogicMonitorClient.cs
+++ b/LogicMonitor.Api/LogicMonitorClient.cs
@@ -110,8 +110,7 @@ public partial class LogicMonitorClient : IDisposable
 	/// Create a LogicMonitor client
 	/// </summary>
 	/// <param name="logicMonitorClientOptions">The options</param>
-	public LogicMonitorClient(
-		LogicMonitorClientOptions logicMonitorClientOptions)
+	public LogicMonitorClient(LogicMonitorClientOptions logicMonitorClientOptions)
 	{
 		// Set up the logger
 		_logger = logicMonitorClientOptions.Logger ?? new NullLogger<LogicMonitorClient>();
@@ -133,6 +132,11 @@ public partial class LogicMonitorClient : IDisposable
 		_client.DefaultRequestHeaders.Add("X-version", "3");
 		_client.DefaultRequestHeaders.Add("X-CSRF-Token", "Fetch");
 		_client.Timeout = TimeSpan.FromSeconds(logicMonitorClientOptions.HttpClientTimeoutSeconds);
+	}
+
+	public LogicMonitorClient(LogicMonitorClientOptions logicMonitorClientOptions, HttpClient client) : this(logicMonitorClientOptions)
+	{
+		_client = client;
 	}
 
 	private static string GetSignature(string httpVerb, long epoch, string data, string resourcePath, string accessKey)


### PR DESCRIPTION
Hello everyone,
In our project, I need to set an additional header on the Http client. As the Http client is not accessible, this was not possible until now.
My modification adds a new constructor. This takes an Http client in addition to the options and then sets this in the private property.